### PR TITLE
Fix/pyproject and gsl fetch

### DIFF
--- a/build_gsl.sh
+++ b/build_gsl.sh
@@ -12,12 +12,56 @@ else
     CORES=$(sysctl -n hw.ncpu)
 fi
 
-# Download source (use mirror redirector + retries)
+# Download source.
+#
+# curl's --retry only covers transient HTTP responses (408, 429, 5xx) and timeouts, so a
+# mid-transfer connection reset -- exit 35, which is how a bad GNU mirror usually fails --
+# was not retried at all. --retry-all-errors fixes that; --speed-limit/--speed-time abort a
+# transfer that has stalled so the retry actually fires instead of hanging on a dead
+# mirror; and the loop falls through to named mirrors rather than trusting whichever host
+# the ftpmirror redirector picks.
+GSL_TARBALL="gsl-${GSL_VERSION}.tar.gz"
+# Optional integrity check: set GSL_SHA256 to the published checksum to enable it.
+GSL_SHA256="${GSL_SHA256:-}"
+
+fetch_gsl() {
+    curl --fail --location \
+        --retry 5 --retry-delay 5 --retry-all-errors \
+        --connect-timeout 30 --speed-limit 1024 --speed-time 30 \
+        "$1" -o "${GSL_TARBALL}"
+}
+
 mkdir -p /tmp/gsl-src
 cd /tmp/gsl-src
-curl --fail --location --retry 5 --retry-delay 5 \
-    "https://ftpmirror.gnu.org/gsl/gsl-${GSL_VERSION}.tar.gz" \
-    -o "gsl-${GSL_VERSION}.tar.gz"
+rm -f "${GSL_TARBALL}"
+for url in \
+    "https://ftpmirror.gnu.org/gsl/${GSL_TARBALL}" \
+    "https://ftp.gnu.org/gnu/gsl/${GSL_TARBALL}" \
+    "https://mirrors.kernel.org/gnu/gsl/${GSL_TARBALL}"
+do
+    echo "Fetching ${url}"
+    if fetch_gsl "${url}"; then
+        break
+    fi
+    echo "  mirror failed, trying next" >&2
+    rm -f "${GSL_TARBALL}"
+done
+
+if [ ! -s "${GSL_TARBALL}" ]; then
+    echo "ERROR: could not download ${GSL_TARBALL} from any mirror." >&2
+    exit 1
+fi
+
+if [ -n "${GSL_SHA256}" ]; then
+    echo "Verifying SHA-256..."
+    if command -v sha256sum >/dev/null; then
+        echo "${GSL_SHA256}  ${GSL_TARBALL}" | sha256sum --check --strict
+    else
+        echo "${GSL_SHA256}  ${GSL_TARBALL}" | shasum -a 256 --check --strict
+    fi
+else
+    echo "GSL_SHA256 not set; skipping integrity check." >&2
+fi
 
 tar -xzf "gsl-${GSL_VERSION}.tar.gz"
 cd "gsl-${GSL_VERSION}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "pybhpt"
-version = "0.9.11"
+version = "1.0.0"
 description = "Black Hole Perturbation Theory and Self-Force Algorithms in Python"
 authors = [
   { name = "Zach Nasipak", email = "znasipak@gmail.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,10 @@
 [build-system]
 requires = [
   "cython",
-  "numpy",
+  # Build against the oldest supported 2.x: numpy 2 wheels stay ABI-compatible with newer
+  # runtimes, so the floor here is what matters. The ceiling mirrors the runtime pin below;
+  # leaving it unpinned would compile against a numpy the install step then refuses.
+  "numpy>=2.0,<2.3",
   "scikit-build-core"
 ]
 build-backend = "scikit_build_core.build"
@@ -15,6 +18,7 @@ authors = [
 ]
 readme = "README.md"
 license = "GPL-3.0-or-later"
+license-files = ["LICENSE"]
 classifiers = [
   "Programming Language :: Python :: 3",
   "Programming Language :: Cython",
@@ -23,7 +27,10 @@ classifiers = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-  "numpy <= 2.2",
+  # "<= 2.2" excluded 2.2.1-2.2.6 as well as 2.3; "<2.3" is the intended ceiling. That
+  # ceiling matches numba (pulled in by `spherical` in the extended extra), which requires
+  # numpy<2.3 -- check numba before raising it.
+  "numpy>=1.24,<2.3",
   "scipy"
 ]
 


### PR DESCRIPTION
This pull request improves the robustness and reliability of the build process and clarifies dependency management for the project. The main changes include a more resilient GNU Scientific Library (GSL) download mechanism with integrity checking, precise version pinning for `numpy` in both build and runtime dependencies, and a version bump to `1.0.0`.

**Build process improvements:**

* Enhanced the GSL source download in `build_gsl.sh` to retry failed downloads more reliably, fall back to multiple mirrors, and optionally verify file integrity with SHA-256.

**Dependency management:**

* Updated the build requirement for `numpy` in `pyproject.toml` to `numpy>=2.0,<2.3`, ensuring compatibility with supported wheels and runtime requirements.
* Adjusted the runtime dependency for `numpy` to `numpy>=1.24,<2.3`, clarifying the intended version range and aligning with downstream requirements (e.g., `numba`).

**Project metadata:**

* Bumped the project version from `0.9.11` to `1.0.0` and added a `license-files` entry for clarity.